### PR TITLE
`poijhgvc

### DIFF
--- a/SAR_searcher.py
+++ b/SAR_searcher.py
@@ -17,4 +17,4 @@ q = False
 e = False
 
 if __name__ == "__main__":
-    if len(sys.argv) >= 
+    if len(sys.argv) >= 555


### PR DESCRIPTION
kjhgfdcghjk